### PR TITLE
Added support for xml files in non-UTF8 encoding

### DIFF
--- a/cmd/xmlcutty/main.go
+++ b/cmd/xmlcutty/main.go
@@ -36,6 +36,7 @@ import (
 	"strings"
 
 	"github.com/miku/xmlcutty"
+	"golang.org/x/net/html/charset"
 )
 
 // Version of xmlcutty.
@@ -95,6 +96,7 @@ func main() {
 	stack := xmlcutty.StringStack{}
 	decoder := xml.NewDecoder(reader)
 	decoder.Strict = false
+	decoder.CharsetReader = charset.NewReaderLabel
 
 	var opener, closer string
 	switch *rename {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/miku/xmlcutty
 
 go 1.12
+
+require golang.org/x/net v0.0.0-20190724013045-ca1201d0de80

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
+golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This adds support for non-UTF8 encoded xml files.

Without this if xmlcutty was applied to files with an encoding tag like `<?xml version="1.0" encoding="ISO-8859-1"?>` processing would terminate with an error like 
```2019/08/01 07:55:02 xml: encoding "ISO-8859-1" declared but Decoder.CharsetReader is nil``` 